### PR TITLE
Fixed typo "deployied" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd ~/environment/demo-soafee-aws-iotfleetwise
 ./scripts/deploy-cloud.sh
 ```
 
-The above commands will take about **10 minutes** to complete. While you wait we encorage you to appreciate how the cloud resources gets deployied through [CDK](https://aws.amazon.com/cdk/) leveraging the [AWS IoT FleetWise Construct Library](https://github.com/aws-samples/cdk-aws-iotfleetwise) having a look to [this file](https://github.com/aws-samples/demo-soafee-aws-iotfleetwise/blob/main/cloud/src/main.py).
+The above commands will take about **10 minutes** to complete. While you wait we encorage you to appreciate how the cloud resources gets deployed through [CDK](https://aws.amazon.com/cdk/) leveraging the [AWS IoT FleetWise Construct Library](https://github.com/aws-samples/cdk-aws-iotfleetwise) having a look to [this file](https://github.com/aws-samples/demo-soafee-aws-iotfleetwise/blob/main/cloud/src/main.py).
 
 ### Get AWS FleetWise Edge running on the Build Host
 


### PR DESCRIPTION
*Description of changes:*

Fixed typo, "deployied" -> "deployed"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
