### PR TITLE
bug fix : changed instance type to m5 (m4 no longer available).

### DIFF
--- a/cloud9/src/mainstack.py
+++ b/cloud9/src/mainstack.py
@@ -20,7 +20,7 @@ class MainStack(Stack):
         super().__init__(scope, construct_id, **kwargs)
 
         c9 = cloud9.CfnEnvironmentEC2(self,'MyCfnEnvironmentEC2',
-            instance_type='m4.large',
+            instance_type='m5.large',
             automatic_stop_time_minutes=120,
             image_id='ubuntu-18.04-x86_64',
             name='Demo SOAFEE AWS IoT Fleetwise',


### PR DESCRIPTION
*Issue #, if available:*

The instances used in the cloud9 desktop are no longer available (m4.large). 


*Description of changes:*
I upgraded the instance type to m5.large.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
