### PR TITLE
bug fix : upgraded ubuntu 18.04 to 22.04

### DIFF
--- a/cloud9/src/mainstack.py
+++ b/cloud9/src/mainstack.py
@@ -25,7 +25,6 @@ class MainStack(Stack):
             image_id='ubuntu-22.04-x86_64',
             name='Demo SOAFEE AWS IoT Fleetwise',
             description='Demo SOAFEE AWS IoT Fleetwise',
-            owner_arn='arn:aws:sts::423752711601:assumed-role/GenAI-hackathon-data-generation/aandraca-Isengard',
             repositories=[
                 cloud9.CfnEnvironmentEC2.RepositoryProperty(
                     path_component='/demo-soafee-aws-iotfleetwise',

--- a/cloud9/src/mainstack.py
+++ b/cloud9/src/mainstack.py
@@ -22,9 +22,10 @@ class MainStack(Stack):
         c9 = cloud9.CfnEnvironmentEC2(self,'MyCfnEnvironmentEC2',
             instance_type='m5.large',
             automatic_stop_time_minutes=120,
-            image_id='ubuntu-18.04-x86_64',
+            image_id='ubuntu-22.04-x86_64',
             name='Demo SOAFEE AWS IoT Fleetwise',
             description='Demo SOAFEE AWS IoT Fleetwise',
+            owner_arn='arn:aws:sts::423752711601:assumed-role/GenAI-hackathon-data-generation/aandraca-Isengard',
             repositories=[
                 cloud9.CfnEnvironmentEC2.RepositoryProperty(
                     path_component='/demo-soafee-aws-iotfleetwise',


### PR DESCRIPTION
*Issue #, if available:*

python packages are no longer available for the python version shipped with ubuntu 18.04, therefore the deploy_cloud.sh step is failing


*Description of changes:*
upgraded the AMI to use ubuntu 22.04, deployed the solution and all the steps work correctly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
